### PR TITLE
fix(deps): pin neutron-lib<3.23.0 to fix CI test failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask
 neutron
-neutron-lib
+neutron-lib<3.23.0


### PR DESCRIPTION
## Problem

All CI test runs fail during test collection with:

```
AttributeError: module 'neutron_lib.constants' has no attribute 'ACCESS_READONLY'
```

This is caused by `neutron-lib>=3.23.0` removing the `ACCESS_READONLY` constant, while `neutron`'s `external_net_db.py` still references it.

## Root Cause

- `neutron-lib 3.23.0` removed `constants.ACCESS_READONLY` 
- `neutron` (latest) requires `neutron-lib>=3.21.1`, so pip resolves to `3.23.0+`
- `neutron/db/external_net_db.py` line 41 still references `constants.ACCESS_READONLY`
- This breaks test collection when importing `neutron.tests.unit.db.test_allowedaddresspairs_db`

## Fix

Pin `neutron-lib<3.23.0` in `requirements.txt` until upstream `neutron` is updated.

This also fixes the CI failure on PR #10 (StepSecurity).