### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ jobs:
   linters:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       - run: uvx tox -elinters
 
   py:
@@ -20,9 +20,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: uvx tox -epy3


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full commit SHAs instead of mutable version tags.

This prevents supply chain attacks where a compromised tag could silently inject malicious code into CI/CD pipelines (similar to the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)).

### Changes

- Replace tag-based references (e.g., `@v4`) with full 40-character commit SHA pins
- Add version comments (e.g., `# v4`) for human readability

### Why

- **Immutability**: Git tags can be force-pushed, but commit SHAs cannot be changed
- **Supply chain security**: Prevents tag hijacking attacks
- **Auditability**: Each pinned version is traceable to an exact commit
